### PR TITLE
Update Yorick URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-prefix: "http://dhmunro.github.com/yorick-doc"
+prefix: "https://software.llnl.gov/yorick-doc"
 pkgname: "yorick-av"
 pkgtitle: "make movies in various formats using FFmpeg / LibAV"
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,5 @@
 <ul>
-<li><a href="http://yorick.github.com">Home</a></li>
+<li><a href="{{prefix}}/">Home</a></li>
 <li><a href="{{prefix}}/downloads.html">Downloads</a></li>
 <li>Documentation<ul>
   <li><a href="{{prefix}}/manual/yorick.html">User Manual</a></li>
@@ -7,10 +7,10 @@
   <li><a href="{{prefix}}/stdlib/index.html">Standard Library</a></li>
   <li><a href="{{prefix}}/plugins/index.html">Plugins and Packages</a></li>
   </ul></li>
-<li><a href="http://github.com/dhmunro/yorick"
+<li><a href="https://github.com/LLNL/yorick"
        target="_blank">Browse Source Code</a></li>
 <li><a href="http://yorick.sourceforge.net/phpBB3"
        target="_blank">User Forums</a></li>
-<li><a href="http://github.com/yorick/yorick.github.com/wiki"
+<li><a href="https://github.com/yorick/yorick.github.com/wiki"
        target="_blank">Wiki</a></li>
 </ul>

--- a/_includes/sideqref.html
+++ b/_includes/sideqref.html
@@ -1,5 +1,5 @@
 <ul>
-<li><a href="http://yorick.github.com">Home</a></li>
+<li><a href="{{prefix}}/">Home</a></li>
 <li><a href="{{prefix}}/manual/yorick.html">User Manual</a></li>
 <li><a href="{{prefix}}/qref/index.html">Quick Reference</a></li>
 <li><a href="{{prefix}}/stdlib/index.html">Standard Library</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 {%include meta.html%}
 
 <div id="header">{{page.anchor}}<h1>
-   <a href="http://yorick.github.com"><img id="banner" src="{{prefix}}/images/skull-banner.png" alt="Yorick"/></a>
+   <a href="{{prefix}}/"><img id="banner" src="{{prefix}}/images/skull-banner.png" alt="Yorick"/></a>
 &nbsp;{{page.headline}}
 </h1></div>
 


### PR DESCRIPTION
GitHub Pages no longer supports (projectname).github.com URLs. They only support (projectname).github.io URLs now. So http://yorick.github.com no longer works.

http://yorick.github.io redirects to https://dhmunro.github.com/yorick-doc which doesn't work. I submitted a PR over there: https://github.com/yorick/yorick.github.com/pull/1

https://dhmunro.github.io/yorick-doc redirects to https://llnl.github.com/yorick-doc which doesn't work. I submitted a PR over there: https://github.com/dhmunro/yorick-doc/pull/1

https://llnl.github.io/yorick-doc/ redirects to https://software.llnl.gov/yorick-doc/ so that's what I'm suggesting to use in your web site here.

I have not tested these changes (I have not built the site locally) but I believe they're correct.